### PR TITLE
bug with no project path fixed

### DIFF
--- a/R/todor.R
+++ b/R/todor.R
@@ -96,7 +96,11 @@ todor_file <- function(file_name, todo_types = NULL) {
 #'
 #' @export
 todor_project_addin <- function() {
-  todor(search_path = rstudioapi::getActiveProject())
+  project_path = rstudioapi::getActiveProject()
+  if (is.null(project_path))
+    stop(paste0("You're not within R project. Change to project, ",
+                "or use `todor_file` instead."))
+  todor(search_path = project_path)
 }
 
 #' Todor package addin


### PR DESCRIPTION
Related to a bug with projects described in #14 .  It throws an error when not in project.