### PR TITLE
Packrat support

### DIFF
--- a/R/todor.R
+++ b/R/todor.R
@@ -41,7 +41,7 @@ todor <- function(todo_types = NULL, search_path = getwd(), file = NULL) {
       rhtmlfiles <- list_files_with_extension("Rhtml", search_path)
       files <- c(files, rhtmlfiles)
     }
-    if (getOption("todor_exlude_packrat", TRUE)){
+    if (getOption("todor_exclude_packrat", TRUE)) {
       # Remove all filesnames, which include the packrat directory
       files <- files[!stringr::str_detect(files, "/packrat/")]
     }

--- a/R/todor.R
+++ b/R/todor.R
@@ -12,7 +12,7 @@ DEFAULT_PATTERNS <- "default.csv"
 #'
 #' Called on project that are not R packages. Checks all places in the code which require amendents
 #' as specified in \code{todo_types} on R and r files. When option \code{todor_rmd} is set to TRUE
-#' it searches also through Rmd files.
+#' it searches also through Rmd files. Unless option \code{todor_exlude_packrat} is set to FALSE, all files in the packrat directory are excluded.
 #' It triggers rstudio markers to appear.
 #'
 #' @param todo_types vector with character describing types of elements to detect.
@@ -40,6 +40,10 @@ todor <- function(todo_types = NULL, search_path = getwd(), file = NULL) {
     if (getOption("todor_rhtml", FALSE)) {
       rhtmlfiles <- list_files_with_extension("Rhtml", search_path)
       files <- c(files, rhtmlfiles)
+    }
+    if (getOption("todor_exlude_packrat", TRUE)){
+      # Remove all filesnames, which include the packrat directory
+      files <- files[!stringr::str_detect(files, "/packrat/")]
     }
   }
   else {


### PR DESCRIPTION
Hi. 
I really like the todoR-Package functionalities. 
When working with packrat in a project, the todor() function also searched through directories and files within the packrat directory, which lead to the display of all TODOs in all the installed packages, which makes the output rather unclear.

I added the exclusion of the packrat directory as a default, as the occasions where you want to do something to a package source code in a packrat directory might be quite rare. The directory can be included via options(todor_exclude_packrat = FALSE)

Best,
Tim