### PR TITLE
Fixed typo on option documentation.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,5 +12,5 @@ Imports: stringr,
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Suggests: testthat

--- a/R/todor.R
+++ b/R/todor.R
@@ -24,7 +24,7 @@ rex::register_shortcuts("todor")
 #' \code{todor_rhtml} - when set to TRUE it searches also through
 #' Rhtml files (default FALSE).
 #'
-#' \code{todor_exlude_packrat} when set to FALSE, all files in the
+#' \code{todor_exclude_packrat} when set to FALSE, all files in the
 #' "packrat" directory are excluded (default TRUE).
 #'
 #' \code{todor_exclude_r} when TRUE, it ignores R and r files (default FALSE)

--- a/README.md
+++ b/README.md
@@ -123,6 +123,6 @@ options(todor_exclude_r = FALSE)
 Excluding packrat directory.
 
 ```r
-options(todor_exlude_packrat = TRUE)
+options(todor_exclude_packrat = TRUE)
 ```
 

--- a/man/todor.Rd
+++ b/man/todor.Rd
@@ -35,7 +35,7 @@ Rnw files (default FALSE).
 \code{todor_rhtml} - when set to TRUE it searches also through
 Rhtml files (default FALSE).
 
-\code{todor_exlude_packrat} when set to FALSE, all files in the
+\code{todor_exclude_packrat} when set to FALSE, all files in the
 "packrat" directory are excluded (default TRUE).
 
 \code{todor_exclude_r} when TRUE, it ignores R and r files (default FALSE)


### PR DESCRIPTION
Hello,

There was a typo in the option documentation, it states `todor_exlude_packrat` instead of  `todor_exclude_packrat`.

It is a small typo, but it can lead to misbehavior since it is in the option name.

I had rerun `devtools::document()` already.