### PR TITLE
An option to search in the vignettes directory added

### DIFF
--- a/R/todor.R
+++ b/R/todor.R
@@ -72,6 +72,10 @@ todor <- function(todo_types = NULL, search_path = getwd(),
       rhtmlfiles <- list_files_with_extension("Rhtml", search_path)
       files <- c(files, rhtmlfiles)
     }
+    if (getOption("todor_vignettes", FALSE)) {
+      vigfiles <- list_files_with_extension("Rmd", file.path(search_path, "vignettes"))
+      files <- c(files, vigfiles)
+    }
     if (getOption("todor_exclude_packrat", TRUE)) {
       files <- files[!stringr::str_detect(files, "/packrat/")]
     }


### PR DESCRIPTION
As a response to #54. Requires some testing.

```r
options(todor_vignettes = TRUE)
```